### PR TITLE
ci: wrap cargo publish details in details codeblock

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -6,8 +6,18 @@
 			"getPublishedVersion": "cargo search ${ pkg.pkg } --limit 1 | sed -nE 's/^[^\"]*\"//; s/\".*//1p' -",
 			"publish": [
 				{
+					"command": "echo '<details>\n<summary><em><h4>Cargo Publish</h4></em></summary>\n\n```'",
+					"dryRunCommand": true,
+					"pipe": true
+				},
+				{
 					"command": "cargo publish",
 					"dryRunCommand": "cargo publish --dry-run",
+					"pipe": true
+				},
+				{
+					"command": "echo '```\n\n</details>\n'",
+					"dryRunCommand": true,
 					"pipe": true
 				}
 			]


### PR DESCRIPTION
Missed initially for the `0.1.0`.

![image](https://github.com/Beanow/kc11b04-rs/assets/497556/c8bf0252-efdf-4939-af92-bd1d5b77c7dc)
