### PR TITLE
fix: Include doc images in package which should fix docs.rs builds.

### DIFF
--- a/.changes/fix-docsrs.md
+++ b/.changes/fix-docsrs.md
@@ -1,0 +1,5 @@
+---
+"kc11b04": patch
+---
+
+Include doc images in package which should fix docs.rs builds.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 rust-version = "1.60.0"
 include = [
   "/**/*.rs",
+  "/docs",
   "/Cargo.toml",
   "/README.md",
   "/CHANGELOG.md",


### PR DESCRIPTION
Whoops: https://docs.rs/crate/kc11b04/0.2.0/builds/946375

```
$ cargo package --list

.cargo_vcs_info.json
CHANGELOG.md
Cargo.toml
Cargo.toml.orig
LICENSE-APACHE
LICENSE-MIT
README.md
docs/KC11B04-schema.svg
docs/KC11B04.webp
src/driver.rs
src/lib.rs
src/mapping.rs
```