### PR TITLE
doc: Fix link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - [`1c3c5f5`](https://github.com/Beanow/kc11b04-rs/commit/1c3c5f512f2a8e6f637012ffdbd6742b213cc888)([#7](https://github.com/Beanow/kc11b04-rs/pull/7)) Custom maps can now be created.
 
   Either using the macro `map_from_max!` or constructing a `KeyMap` manually.
-  See [`kc11b04::mapping`](https://docs.rs/kc11b04/0.2.0/kc11b04/mapping/index.html) docs.
+  See [`kc11b04::mapping`](https://docs.rs/kc11b04/0.2.1/kc11b04/mapping/index.html) docs.
+
 - [`4e43c76`](https://github.com/Beanow/kc11b04-rs/commit/4e43c7604ab655606ff3343a40e00afcb9922469)([#5](https://github.com/Beanow/kc11b04-rs/pull/5)) Expand documentation with examples and images.
 
 ## \[0.1.0]


### PR DESCRIPTION
As `0.2.0` failed to build on docs.rs, the assumed link to the docs does not exist. Using `0.2.1` link instead.